### PR TITLE
add overload param to constructure method

### DIFF
--- a/src/Dotenv.php
+++ b/src/Dotenv.php
@@ -11,11 +11,17 @@ class Dotenv
      *
      * @param string $path
      * @param string $file
+     * @param boolean $overload
      * @return void
      */
-    public function __construct($path, $file = '.env')
+    public function __construct($path, $file = '.env', $overload = false)
     {
-        (new PHPDotenv($path, $file))
-            ->load();
+      $dotEnv = new PHPDotenv($path, $file);
+
+      if ($overload) {
+        $dotEnv->overload();
+      } else {
+        $dotEnv->load();
+      }
     }
 }


### PR DESCRIPTION
PR contains the following

* Added param constructer with default param (false)
* Added comment to constructer method
* Added condition to initialize the dotENV library

I think this will be a nice feature because sometimes I need to overwrite environment variables which already set up by hosting provider.